### PR TITLE
typography changes to make headings stand out more

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -58,3 +58,14 @@ label[for="__drawer"] {
 .md-main__inner {
     margin-top: 0;
 }
+
+/* make the method names in API references stand out more */
+.md-typeset h3 {
+    font-weight: bold;
+    font-size: 1.4em;
+}
+
+/* swap the top/bottom margin of h1 */
+.md-typeset h1 {
+    margin: 1.25em 0 0;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ plugins:
             filters:
               - "!^_"  # exlude all members starting with _
               - "^__init__$"  # but always include __init__ modules and methods
+      custom_templates: templates
 
 
 markdown_extensions:

--- a/templates/python/material/method.html
+++ b/templates/python/material/method.html
@@ -1,0 +1,66 @@
+{{ log.debug() }}
+{% if config.show_if_no_docstring or method.has_contents %}
+
+  <div class="doc doc-object doc-method">
+  {% with html_id = method.path %}
+
+    {% if not root or config.show_root_heading %}
+
+      {% if root %}
+        {% set show_full_path = config.show_root_full_path %}
+        {% set root_members = True %}
+      {% elif root_members %}
+        {% set show_full_path = config.show_root_members_full_path or config.show_object_full_path %}
+        {% set root_members = False %}
+      {% else %}
+        {% set show_full_path = config.show_object_full_path %}
+      {% endif %}
+
+      {% filter heading(heading_level,
+          role="method",
+          id=html_id,
+          class="doc doc-heading",
+          toc_label=method.name ~ "()") %}
+
+        {{ method.name }}
+
+        {% with properties = method.properties %}
+          {% include "properties.html" with context %}
+        {% endwith %}
+
+      {% endfilter %}
+
+    {% else %}
+      {% if config.show_root_toc_entry %}
+        {% filter heading(heading_level,
+            role="method",
+            id=html_id,
+            toc_label=method.path,
+            hidden=True) %}
+        {% endfilter %}
+      {% endif %}
+      {% set heading_level = heading_level - 1 %}
+    {% endif %}
+
+    <div class="doc doc-contents {% if root %}first{% endif %}">
+      {% filter highlight(language="python", inline=True) %}
+          {% if show_full_path %}{{ method.path }}{% else %}{{ method.name }}{% endif %}
+          {% with signature = method.signature %}{% include "signature.html" with context %}{% endwith %}
+      {% endfilter %}
+
+      {% with docstring_sections = method.docstring_sections %}
+        {% include "docstring.html" with context %}
+      {% endwith %}
+
+      {% if config.show_source and method.source %}
+        <details class="quote">
+          <summary>Source code in <code>{{ method.relative_file_path }}</code></summary>
+          {{ method.source.code|highlight(language="python", linestart=method.source.line_start, linenums=False) }}
+        </details>
+      {% endif %}
+    </div>
+
+  {% endwith %}
+  </div>
+
+{% endif %}


### PR DESCRIPTION
1. Use method names as the section heading and apply a larger/heavier font to make it stand out. The signature is nested below with a smaller font.

[before]
![image](https://user-images.githubusercontent.com/3463757/147147761-aa900012-5938-49f2-b5c4-895ab90e7c4f.png)

[after]
![image](https://user-images.githubusercontent.com/3463757/147147395-4901e9c7-f146-48bf-aaf1-e4a564aa8ff2.png)

2. Swap the top and bottom margins of `h1` so the heading is visually closer to its content

[before]
![image](https://user-images.githubusercontent.com/3463757/147147686-edbfd9de-3768-4e07-a1ef-0c28e8e6b4cd.png)

[after]
![image](https://user-images.githubusercontent.com/3463757/147147524-082e3a88-b3e5-478c-9cd1-87fe34d68b74.png)
